### PR TITLE
Get rid of `__send__`

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -383,7 +383,7 @@ module Net # :nodoc:
       len = writing {
         using_each_crlf_line {
           begin
-            block.call(WriteAdapter.new(self, :write_message_0))
+            block.call(WriteAdapter.new(self.method(:write_message_0)))
           rescue LocalJumpError
             # allow `break' from writer block
           end
@@ -447,17 +447,16 @@ module Net # :nodoc:
   # The writer adapter class
   #
   class WriteAdapter
-    def initialize(socket, method)
-      @socket = socket
-      @method_id = method
+    def initialize(writer)
+      @writer = writer
     end
 
     def inspect
-      "#<#{self.class} socket=#{@socket.inspect}>"
+      "#<#{self.class} writer=#{@writer.inspect}>"
     end
 
     def write(str)
-      @socket.__send__(@method_id, str)
+      @writer.call(str)
     end
 
     alias print write


### PR DESCRIPTION
Mitigate the security risk:
https://devcraft.io/2021/01/07/universal-deserialisation-gadget-for-ruby-2-x-3-x.html