### PR TITLE
Avoid rbuf copying on the first read

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -151,10 +151,15 @@ module Net # :nodoc:
 
     public
 
-    def read(len, dest = ''.b, ignore_eof = false)
+    def read(len, dest = nil, ignore_eof = false)
       LOG "reading #{len} bytes..."
-      read_bytes = 0
       begin
+        if dest.nil?
+          dest = read_initial(len)
+          read_bytes = dest.bytesize
+        else
+          read_bytes = 0
+        end
         while read_bytes + rbuf_size < len
           if s = rbuf_consume_all_shareable!
             read_bytes += s.bytesize
@@ -172,10 +177,15 @@ module Net # :nodoc:
       dest
     end
 
-    def read_all(dest = ''.b)
+    def read_all(dest = nil)
       LOG 'reading all...'
-      read_bytes = 0
       begin
+        if dest.nil?
+          dest = read_initial
+          read_bytes = dest.bytesize
+        else
+          read_bytes = 0
+        end
         while true
           if s = rbuf_consume_all_shareable!
             read_bytes += s.bytesize
@@ -283,6 +293,11 @@ module Net # :nodoc:
 
       @debug_output << %Q[-> #{s.dump}\n] if @debug_output
       s
+    end
+
+    def read_initial(len = nil)
+      rbuf_fill if @rbuf_empty
+      rbuf_consume(len)
     end
 
     #

--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -274,7 +274,7 @@ module Net # :nodoc:
     end
 
     def rbuf_consume(len = nil)
-      if @rbuf_offset == 0 && (len.nil? || len == @rbuf.bytesize)
+      if @rbuf_offset == 0 && (len.nil? || len >= @rbuf.bytesize)
         s = @rbuf
         @rbuf = ''.b
         @rbuf_offset = 0


### PR DESCRIPTION
When the caller doesn't specify the destination, there's no need to append the rbuf to empty string - the rbuf slice itself could be used as initial dest value.