### PR TITLE
Initialize @rbuf_empty in BufferedIO

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -120,6 +120,7 @@ module Net # :nodoc:
       @continue_timeout = continue_timeout
       @debug_output = debug_output
       @rbuf = ''.b
+      @rbuf_empty = true
       @rbuf_offset = 0
     end
 

--- a/test/net/protocol/test_protocol.rb
+++ b/test/net/protocol/test_protocol.rb
@@ -57,6 +57,14 @@ class TestProtocol < Test::Unit::TestCase
     mockio
   end
 
+  def test_readuntil
+    assert_output("", "") do
+      sio = StringIO.new("12345".dup)
+      io = Net::BufferedIO.new(sio)
+      assert_equal "12345", io.readuntil("5")
+    end
+  end
+
   def test_write0_multibyte
     mockio = create_mockio(max: 1)
     io = Net::BufferedIO.new(mockio)


### PR DESCRIPTION
https://github.com/ruby/net-protocol/pull/14 is causing a warning under Ruby 2.7 when the instance variable is first used without having been initialized first.

I know this warning has been removed since Ruby 3.0, but with object shapes coming up it might be good anyway to make sure all instances share all the same shape transitions that way none of the instance variable reads will get cache misses.