### PR TITLE
Failing test case for #19

### DIFF
--- a/test/net/protocol/test_protocol.rb
+++ b/test/net/protocol/test_protocol.rb
@@ -127,4 +127,33 @@ class TestProtocol < Test::Unit::TestCase
     io.write_timeout = 0.1
     assert_raise(Net::WriteTimeout){ io.write("a"*50,"a"*50,"a") }
   end
+
+  class FakeReadPartialIO
+    def initialize(chunks)
+      @chunks = chunks.map(&:dup)
+    end
+
+    def read_nonblock(size, buf = nil, exception: false)
+      if buf
+        buf.replace(@chunks.shift)
+        buf
+      else
+        @chunks.shift
+      end
+    end
+  end
+
+  def test_shareable_buffer_leak # https://github.com/ruby/net-protocol/pull/19
+    expected_chunks = [
+      "aaaaa",
+      "bbbbb",
+    ]
+    fake_io = FakeReadPartialIO.new(expected_chunks)
+    io = Net::BufferedIO.new(fake_io)
+    actual_chunks = []
+    reader = Net::ReadAdapter.new(-> (chunk) { actual_chunks << chunk })
+    io.read(5, reader)
+    io.read(5, reader)
+    assert_equal expected_chunks, actual_chunks
+  end
 end


### PR DESCRIPTION
Unfortunately we have to use a mock, but this test demonstrate the mutation bug fixed in #19.

It fails on 0.2.0 but passes on 0.1.3 or 0.2.1.

cc @hsbt @nurse