### PR TITLE
Respect unread buffered data when checking EOF

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -171,7 +171,7 @@ module Net # :nodoc:
     end
 
     def eof?
-      @io.eof?
+      @rbuf_empty && @io.eof?
     end
 
     def closed?


### PR DESCRIPTION
## Summary

Return false from BufferedIO#eof? while unread bytes remain in its own buffer. Only ask the underlying IO after that buffer is exhausted.

## Reproduction

```ruby
require 'net/protocol'
require 'stringio'
io = Net::BufferedIO.new(StringIO.new("one\ntwo\n"))
p io.readline # "one"
p io.eof?     # before: true; after: false
p io.readline # "two"
p io.eof?     # true
```

A bounded local Socket.pair reproduction also shows the old eof? blocking while a complete second line is already buffered and the peer remains open. The patched call returns false without waiting. The remaining buffered line is preserved when the peer closes.

## Verification

- Ruby 4.0.6 via rbenv; reviewed master `6cba9756b72eaa5a939b4cb6e032ec1da88b07bd`.
- Existing `bundle exec rake test`: 30 tests, 66 assertions, zero failures/errors on the baseline and this branch.
- eof: 19 checks, 0 failures in an external scratch script; baseline fails the affected expectations.
- Ruby syntax and `git diff --check` pass. Supplemental RuboCop Lint has the same 11 pre-existing offenses; no lint-clean claim.
- No repository tests added or modified, following the consuming project's explicit no-new-tests instruction. The reproduction is included here for maintainer use.
- Existing PRs/issues were checked for overlap, including #14, #30, #66 and #67. This change does not replace their buffering/terminator/read-limit fixes.

## Compatibility and limitations

No signature changes. eof? intentionally stops reporting EOF, or waiting on the underlying socket, while this wrapper still has unread data.

The patch also applies to installed release 0.3.0, whose runtime file matches the reviewed master. Gem version, dependencies and Ruby >= 2.6 requirement stay unchanged. Only macOS/Ruby 4.0.6 was run locally; other Ruby/OS combinations require upstream CI. No production traffic or external service was used.
