### PR TITLE
Reject negative read lengths before changing the buffer

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -189,6 +189,7 @@ module Net # :nodoc:
     public
 
     def read(len, dest = ''.b, ignore_eof = false)
+      raise ArgumentError, "negative length #{len} given" if len < 0
       LOG "reading #{len} bytes..."
       read_bytes = 0
       begin


### PR DESCRIPTION
## Summary

Reject a negative read length before touching the destination or advancing the read-buffer offset. The current failure can move the offset backwards and expose bytes already consumed.

## Reproduction

```ruby
require 'net/protocol'
require 'stringio'
io = Net::BufferedIO.new(StringIO.new('abcdef'))
p io.read(1) # "a"
begin
  io.read(-1)
rescue => e
  p e.class # before: NoMethodError; after: ArgumentError
end
p io.read_all # before: "abcdef"; after: "bcdef"
```

Focused checks cover three initial offsets, small and arbitrarily large negative integers, both ignore_eof values, unchanged destination contents, zero/positive reads and EOF behavior.

## Verification

- Ruby 4.0.6 via rbenv; reviewed master `6cba9756b72eaa5a939b4cb6e032ec1da88b07bd`.
- Existing `bundle exec rake test`: 30 tests, 66 assertions, zero failures/errors on the baseline and this branch.
- negative: 59 checks, 0 failures in an external scratch script; baseline fails the affected expectations.
- Ruby syntax and `git diff --check` pass. Supplemental RuboCop Lint has the same 11 pre-existing offenses; no lint-clean claim.
- No repository tests added or modified, following the consuming project's explicit no-new-tests instruction. The reproduction is included here for maintainer use.
- Existing PRs/issues were checked for overlap, including #14, #30, #66 and #67. This change does not replace their buffering/terminator/read-limit fixes.

## Compatibility and limitations

Negative lengths now raise ArgumentError rather than an incidental NoMethodError/RangeError. This is an intentional error-contract correction. Valid lengths and existing destination-append semantics are unchanged; no new coercion rules are introduced.

The patch also applies to installed release 0.3.0, whose runtime file matches the reviewed master. Gem version, dependencies and Ruby >= 2.6 requirement stay unchanged. Only macOS/Ruby 4.0.6 was run locally; other Ruby/OS combinations require upstream CI. No production traffic or external service was used.
