### PR TITLE
Wait for readability when an SSL write requests it

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -384,6 +384,9 @@ module Net # :nodoc:
             # next string
           end
           # continue looping
+        when :wait_readable
+          (io = @io.to_io).wait_readable(@write_timeout) or raise Net::WriteTimeout.new(io)
+          # continue looping
         when :wait_writable
           (io = @io.to_io).wait_writable(@write_timeout) or raise Net::WriteTimeout.new(io)
           # continue looping


### PR DESCRIPTION
## Summary

Handle :wait_readable from write_nonblock(exception: false), wait with write_timeout, and raise Net::WriteTimeout if readiness is not reached. The current case statement retries that result immediately without any wait or timeout.

## Reproduction

[OpenSSL::Buffering#write_nonblock documents both readiness directions](https://ruby.github.io/openssl/OpenSSL/Buffering.html#method-i-write_nonblock), including :wait_readable with exception: false.

```ruby
require 'net/protocol'
writer = Object.new
writes = waits = 0
writer.define_singleton_method(:to_io) { self }
writer.define_singleton_method(:wait_readable) { |timeout| waits += 1; true }
writer.define_singleton_method(:write_nonblock) do |str, exception:|
  writes += 1
  writes == 1 ? :wait_readable : str.bytesize
end
p Net::BufferedIO.new(writer, write_timeout: 0.125).write('abc') # 3
p waits # before: 0; after: 1
```

Bounded deterministic IO doubles also cover timeout without a retry, partial writes, multiple strings, alternating readiness directions, preserved output and the timeout's IO reference.

## Verification

- Ruby 4.0.6 via rbenv; reviewed master `6cba9756b72eaa5a939b4cb6e032ec1da88b07bd`.
- Existing `bundle exec rake test`: 30 tests, 66 assertions, zero failures/errors on the baseline and this branch.
- readiness: 18 checks, 0 failures in an external scratch script; baseline fails the affected expectations.
- Ruby syntax and `git diff --check` pass. Supplemental RuboCop Lint has the same 11 pre-existing offenses; no lint-clean claim.
- No repository tests added or modified, following the consuming project's explicit no-new-tests instruction. The reproduction is included here for maintainer use.
- Existing PRs/issues were checked for overlap, including #14, #30, #66 and #67. This change does not replace their buffering/terminator/read-limit fixes.

## Compatibility and limitations

No signature changes. A write waiting for read readiness now honors write_timeout instead of busy-retrying. Validation exercises the documented IO contract; it does not claim a reproduced live TLS renegotiation or cross-platform TLS test.

The patch also applies to installed release 0.3.0, whose runtime file matches the reviewed master. Gem version, dependencies and Ruby >= 2.6 requirement stay unchanged. Only macOS/Ruby 4.0.6 was run locally; other Ruby/OS combinations require upstream CI. No production traffic or external service was used.
