### PR TITLE
Restore message logging and clear write state on exceptional exits

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -356,9 +356,9 @@ module Net # :nodoc:
       @debug_output << '<- ' if @debug_output
       yield
       @debug_output << "\n" if @debug_output
-      bytes = @written_bytes
+      @written_bytes
+    ensure
       @written_bytes = nil
-      bytes
     end
 
     def write0(*strs)
@@ -426,12 +426,15 @@ module Net # :nodoc:
     def each_message_chunk
       LOG 'reading message...'
       LOG_off()
-      read_bytes = 0
-      while (line = readuntil("\r\n")) != ".\r\n"
-        read_bytes += line.size
-        yield line.delete_prefix('.')
+      begin
+        read_bytes = 0
+        while (line = readuntil("\r\n")) != ".\r\n"
+          read_bytes += line.size
+          yield line.delete_prefix('.')
+        end
+      ensure
+        LOG_on()
       end
-      LOG_on()
       LOG "read message (#{read_bytes} bytes)"
     end
 
@@ -457,12 +460,15 @@ module Net # :nodoc:
     def write_message(src)
       LOG "writing message from #{src.class}"
       LOG_off()
-      len = writing {
-        using_each_crlf_line {
-          write_message_0 src
+      begin
+        len = writing {
+          using_each_crlf_line {
+            write_message_0 src
+          }
         }
-      }
-      LOG_on()
+      ensure
+        LOG_on()
+      end
       LOG "wrote #{len} bytes"
       len
     end
@@ -470,16 +476,19 @@ module Net # :nodoc:
     def write_message_by_block(&block)
       LOG 'writing message from block'
       LOG_off()
-      len = writing {
-        using_each_crlf_line {
-          begin
-            block.call(WriteAdapter.new(self.method(:write_message_0)))
-          rescue LocalJumpError
-            # allow `break' from writer block
-          end
+      begin
+        len = writing {
+          using_each_crlf_line {
+            begin
+              block.call(WriteAdapter.new(self.method(:write_message_0)))
+            rescue LocalJumpError
+              # allow `break' from writer block
+            end
+          }
         }
-      }
-      LOG_on()
+      ensure
+        LOG_on()
+      end
       LOG "wrote #{len} bytes"
       len
     end
@@ -499,6 +508,8 @@ module Net # :nodoc:
         write0 "\r\n"
       end
       write0 ".\r\n"
+      nil
+    ensure
       @wbuf = nil
     end
 


### PR DESCRIPTION
## Summary

Restore temporarily disabled message logging and clear temporary write buffers/counters with ensure when reads, sources, writes or user blocks exit exceptionally. Do not finish or send the message terminator on failure.

## Reproduction

```ruby
require 'net/protocol'
require 'stringio'
debug, wire = StringIO.new, StringIO.new
io = Net::InternetMessageIO.new(wire, debug_output: debug)
begin
  io.write_message_by_block { |w| w << 'partial'; raise 'stop' }
rescue RuntimeError
end
p io.debug_output.equal?(debug)         # before: false; after: true
p io.instance_variable_get(:@wbuf)      # before: "partial"; after: nil
p io.instance_variable_get(:@written_bytes) # before: 0; after: nil
p wire.string                          # empty before and after
```

Focused checks cover reader EOF and block exceptions, nonlocal read exits, failing enumerable sources and IO writes, nonlocal writer breaks, successful empty/dot-stuffed/unterminated messages, exact byte counts and ordinary BufferedIO write failure. Original exceptions/return values are preserved.

## Verification

- Ruby 4.0.6 via rbenv; reviewed master `6cba9756b72eaa5a939b4cb6e032ec1da88b07bd`.
- Existing `bundle exec rake test`: 30 tests, 66 assertions, zero failures/errors on the baseline and this branch.
- cleanup: 57 checks, 0 failures in an external scratch script; baseline fails the affected expectations.
- Ruby syntax and `git diff --check` pass. Supplemental RuboCop Lint has the same 11 pre-existing offenses; no lint-clean claim.
- No repository tests added or modified, following the consuming project's explicit no-new-tests instruction. The reproduction is included here for maintainer use.
- Existing PRs/issues were checked for overlap, including #14, #30, #66 and #67. This change does not replace their buffering/terminator/read-limit fixes.

## Compatibility and limitations

No signature changes or successful wire-format changes. Logging is restored after failure, and failed calls no longer retain partial message data/counters. This cleanup does not make a partially failed protocol exchange safe to resume; callers must retain their existing connection-disposal behavior.

The patch also applies to installed release 0.3.0, whose runtime file matches the reviewed master. Gem version, dependencies and Ruby >= 2.6 requirement stay unchanged. Only macOS/Ruby 4.0.6 was run locally; other Ruby/OS combinations require upstream CI. No production traffic or external service was used.
