### PR TITLE
Preserve returned read buffer ownership

### DIFF
--- a/lib/net/protocol.rb
+++ b/lib/net/protocol.rb
@@ -275,7 +275,6 @@ module Net # :nodoc:
           @rbuf_offset = 0
         else
           @rbuf << rv
-          rv.clear
         end
         return
       when :wait_readable


### PR DESCRIPTION
BufferedIO appends a String returned by read_nonblock and then clears that returned object. A custom/nonstandard IO that retains the returned String observes unexpected caller-side mutation, even though BufferedIO only needs its copied bytes. Removing the redundant clear preserves ownership and output.

The external ownership model fails on current master and passes after this change on Ruby 4.0.6 and 3.2.11. The unchanged suite passes 30 tests / 66 assertions on both Rubies; syntax and diff checks pass. No repository tests were changed.